### PR TITLE
Add `.get` usage to custom propery examples

### DIFF
--- a/chapters/the-ember-object.md
+++ b/chapters/the-ember-object.md
@@ -104,16 +104,16 @@ App.User = Ember.Object.extend({
 
 ```coffee
 user = App.User.create()
-user.isHuman #=> true
-user.favoriteDirector #=> "Tarantino"
-user.temperature #=> 98.6
+user.get('isHuman') #=> true
+user.get('favoriteDirector') #=> "Tarantino"
+user.get('temperature') #=> 98.6
 ```
 ```javascript
 var user = App.User.create();
 
-user.isHuman; //=> true
-user.favoriteDirector; //=> "Tarantino"
-user.temperature; //=> 98.6
+user.get('isHuman'); //=> true
+user.get('favoriteDirector'); //=> "Tarantino"
+user.get('temperature'); //=> 98.6
 ```
 
 These are the basic versions of Ember properties. We can also create computed properties that actually do some work and call other properites:


### PR DESCRIPTION
Specifically, the text says on line 103:

"`isHuman`, `temperature`, and `favoriteDirector` would now be accessible with `.get`."

But the examples didn't use the `.get` method to get the values from the properties.
