### PR TITLE
Removes "outlet" to successfully display Hello World

### DIFF
--- a/chapters/hello-world.md
+++ b/chapters/hello-world.md
@@ -125,10 +125,9 @@ Last but not least, we need to create a template for Ember to render. Ember look
 ```haml
 // app/assets/javascripts/templates/application.js.emblem
 h1 Hello World
-outlet
 ```
 
-Restart your server then visit http://localhost:3000. You should see 'Hello World' printed on the screen. If you see it then congratulations! You're one step closer to being an Embereño. Yes, Embereño is a thing, though I kind of like Emberista. 
+Restart your server then visit http://localhost:3000. You should see 'Hello World' printed on the screen. If you see it then congratulations! You're one step closer to being an Embereño. Yes, Embereño is a thing, though I kind of like Emberista.
 
 If you don't see `Hello World`, you should clone my [hello world repo](https://github.com/vicramon/ember-hello-world) and see what you've done differently.
 


### PR DESCRIPTION
Hello, I'm following along in the tutorial and noticed that I wasn't getting "Hello World" to display in the "hello-world" chapter.  When comparing against https://github.com/vicramon/ember-hello-world/blob/master/app/assets/javascripts/templates/application.js.emblem I noticed the tutorial includes "outlet" in the template which is not in your code and when removed displays Hello World correctly.

Thanks for the tutorial, looking forward to getting through it.
